### PR TITLE
fix: explicitly set exit flag in execute script

### DIFF
--- a/execute-vendir.sh
+++ b/execute-vendir.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+set -ex
 
 VENDIR_URL=$1
 TOKEN=$2


### PR DESCRIPTION
when vendir returns an error code the error code is ignored in
the workflow execution. the '-ex' included in the hashbang
prelude is not interpreted by the action toolkit's exec
function.