### PR TITLE
CONFIG-1699 Catch Exec Error and Signal Failure

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
           apiVersion: vendir.k14s.io/v1alpha1
           kind: Config
           directories:
-          - path: vendor/
+          - path: vendor
             contents:
             - path: github.com/zendesk/jsonnet-kubernetes/
               git:

--- a/index.js
+++ b/index.js
@@ -66,16 +66,16 @@ const get = url => {
 }
 
 const run = async () => {
-  const url = await fetchReleases()
   const token = core.getInput('token')
   const locked = core.getInput('locked')
   const vendirFile = core.getInput('vendir_file')
 
-  await exec(path.join(__dirname, 'execute-vendir.sh'), [url, token, locked, vendirFile])
+  try {
+    const url = await fetchReleases()
+    await exec(path.join(__dirname, 'execute-vendir.sh'), [url, token, locked, vendirFile])
+  } catch (error) {
+    core.setFailed(`Action failed with error: ${error}`)
+  }
 }
 
-try {
-  run()
-} catch (error) {
-  core.setFailed(`Action failed with error: ${error}`)
-}
+run()

--- a/vendir.yml
+++ b/vendir.yml
@@ -1,7 +1,7 @@
 apiVersion: vendir.k14s.io/v1alpha1
 kind: Config
 directories:
-- path: vendor/
+- path: vendor
   contents:
   - path: github.com/zendesk/jsonnet-spinnaker/
     git:


### PR DESCRIPTION
when the call to exec returned a rejected promise the error went
unhandled (it wasn't propagated out to the try/catch handler).
moved the try/catch inside of the run function in order to catch
any errors raised as a result of the execute script failing.

[CONFIG-1699](https://zendesk.atlassian.net/browse/CONFIG-1699)
