### PR TITLE
Add working_dir as another input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: zendesk/checkout@v2
       - name: create vendir.yml
-        working_directory: kubernetes
+        working-directory: kubernetes
         run: |
             cat >vendir.yml <<EOL
             apiVersion: vendir.k14s.io/v1alpha1
@@ -60,10 +60,10 @@ jobs:
           token: ${{ secrets.GLOVER_ACCESS_TOKEN }}
           working_dir: kubernetes
       - name: verify vendir.lock.yml
-        working_directory: kubernetes
+        working-directory: kubernetes
         run: |
           cat vendir.lock.yml
       - name: verify vendored directory
-        working_directory: kubernetes
+        working-directory: kubernetes
         run: |
           ls vendor/github.com/zendesk/jsonnet-kubernetes/lib/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,3 +33,36 @@ jobs:
       - name: verify vendored directory
         run: |
           ls vendor/github.com/zendesk/jsonnet-kubernetes/lib/
+  
+  test-working-dir:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zendesk/checkout@v2
+        working_directory: kubernetes
+        run: |
+            cat >vendir.yml <<EOL
+            apiVersion: vendir.k14s.io/v1alpha1
+            kind: Config
+            directories:
+            - path: vendor
+              contents:
+              - path: github.com/zendesk/jsonnet-kubernetes/
+                git:
+                  url: git@github.com:zendesk/jsonnet-kubernetes.git
+                  ref: origin/master
+                includePaths:
+                  - 'lib/K8s.libsonnet'
+            EOL
+      - name: Execute vendir
+        uses: ./
+        with:
+          token: ${{ secrets.GLOVER_ACCESS_TOKEN }}
+          working_dir: kubernetes
+      - name: verify vendir.lock.yml
+        working_directory: kubernetes
+        run: |
+          cat vendir.lock.yml
+      - name: verify vendored directory
+        working_directory: kubernetes
+        run: |
+          ls vendor/github.com/zendesk/jsonnet-kubernetes/lib/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: zendesk/checkout@v2
+      - name: create vendir.yml
         working_directory: kubernetes
         run: |
             cat >vendir.yml <<EOL

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: zendesk/checkout@v2
+      - name: create working directory
+        run:
+          mkdir kubernetes
       - name: create vendir.yml
         working-directory: kubernetes
         run: |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ or
 OPTIONAL, defaults to "false"
 * `vendir_file` - File that defines dependencies. OPTIONAL, defaults to
 `vendir.yml`
+* `working_dir` - Working directory to switch to prior to running vendir, 
+defaults to `.`
 
 
 ## Output

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: File that defines dependencies. OPTIONAL, defaults to "vendir.yml"
     required: false
     default: "vendir.yml"
+  working_dir:
+    description: Working directory to switch to prior to running vendir, defaults to "."
+    required: false
+    default: "."
 runs:
   using: 'node12'
   main: 'index.js'

--- a/execute-vendir.sh
+++ b/execute-vendir.sh
@@ -4,6 +4,9 @@ VENDIR_URL=$1
 TOKEN=$2
 LOCKED=$3
 VENDIR_FILE=$4
+WORKING_DIR=$5
+
+cd $WORKING_DIR
 
 # Download `vendir` binary
 echo "Downloading vendir from: $VENDIR_URL"

--- a/index.js
+++ b/index.js
@@ -69,10 +69,11 @@ const run = async () => {
   const token = core.getInput('token')
   const locked = core.getInput('locked')
   const vendirFile = core.getInput('vendir_file')
+  const workingDir = core.getInput('working_dir')
 
   try {
     const url = await fetchReleases()
-    await exec(path.join(__dirname, 'execute-vendir.sh'), [url, token, locked, vendirFile])
+    await exec(path.join(__dirname, 'execute-vendir.sh'), [url, token, locked, vendirFile, workingDir])
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`)
   }


### PR DESCRIPTION
We have multiple vendir files in our repository within sub directories. We need the ability to go into the sub directory prior to running vendir.