### PR TITLE
feat: add support for target dir in vendir

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,3 +70,41 @@ jobs:
         working-directory: kubernetes
         run: |
           ls vendor/github.com/zendesk/jsonnet-kubernetes/lib/
+
+  test-target-dir:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zendesk/checkout@v2
+      - name: create target directory
+        run:
+          mkdir kubernetes
+      - name: create vendir.yml
+        working-directory: kubernetes
+        run: |
+            cat >vendir.yml <<EOL
+            apiVersion: vendir.k14s.io/v1alpha1
+            kind: Config
+            directories:
+            - path: vendor
+              contents:
+              - path: github.com/zendesk/jsonnet-kubernetes/
+                git:
+                  url: git@github.com:zendesk/jsonnet-kubernetes.git
+                  ref: origin/master
+                includePaths:
+                  - 'lib/K8s.libsonnet'
+            EOL
+      - name: Execute vendir
+        uses: ./
+        with:
+          token: ${{ secrets.GLOVER_ACCESS_TOKEN }}
+          target_dir: kubernetes
+      - name: verify vendir.lock.yml
+        working-directory: kubernetes
+        run: |
+          cat vendir.lock.yml
+      - name: verify vendored directory
+        working-directory: kubernetes
+        run: |
+          ls vendor/github.com/zendesk/jsonnet-kubernetes/lib/
+

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ or
 OPTIONAL, defaults to "false"
 * `vendir_file` - File that defines dependencies. OPTIONAL, defaults to
 `vendir.yml`
-* `working_dir` - Working directory to switch to prior to running vendir, 
-defaults to `.`
+* `working_dir` - Working directory to switch to prior to installing and running vendir, defaults to "."
+* `target_dir` - Target directory for the vendir process, defaults to "."
 
 
 ## Output

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,11 @@ inputs:
     required: false
     default: "vendir.yml"
   working_dir:
-    description: Working directory to switch to prior to running vendir, defaults to "."
+    description: Working directory to switch to prior to installing and running vendir, defaults to "."
+    required: false
+    default: "."
+  target_dir:
+    description: Target directory for the vendir process, defaults to "."
     required: false
     default: "."
 runs:

--- a/execute-vendir.sh
+++ b/execute-vendir.sh
@@ -5,6 +5,7 @@ TOKEN=$2
 LOCKED=$3
 VENDIR_FILE=$4
 WORKING_DIR=$5
+TARGET_DIR=$6
 
 cd $WORKING_DIR
 
@@ -27,7 +28,14 @@ else
   LOCK_OPTION=""
 fi
 
-VENDIR_GITHUB_API_TOKEN=$TOKEN ./vendir sync $LOCK_OPTION -f $VENDIR_FILE
+if [ -z "$TARGET_DIR" ];
+then
+  TARGET_OPTION=""
+else
+  TARGET_OPTION="--chdir $TARGET_DIR"
+fi
+
+VENDIR_GITHUB_API_TOKEN=$TOKEN ./vendir sync $LOCK_OPTION $TARGET_OPTION -f $VENDIR_FILE 
 
 git config --unset-all --global url."https://oauth-token:${TOKEN}@github.com/".insteadof
 cat ~/.gitconfig

--- a/index.js
+++ b/index.js
@@ -71,10 +71,12 @@ const run = async () => {
   const locked = core.getInput('locked')
   const vendirFile = core.getInput('vendir_file')
   const workingDir = core.getInput('working_dir')
-
+  const targetDir = core.getInput('target_dir')
+  
   try {
     const url = await fetchReleases()
-    await exec(path.join(__dirname, 'execute-vendir.sh'), [url, token, locked, vendirFile, workingDir])
+    const executableArgs = [url, token, locked, vendirFile, workingDir, targetDir]
+    await exec(path.join(__dirname, 'execute-vendir.sh'), executableArgs)
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`)
   }


### PR DESCRIPTION
I found when using this action that there is a subtle difference between where we want the vendir action to execute and where we want the vendir binary to execute. It would be nice if we can tell the vendir action where to do it's work. Not just where it is installed.


For example:
```
root # working directory 
├─ kubernetes # target directory
│  └── vendir.yml 
└── vendir # installed binary

```

So i've added a new actions options to setup where to run the `vendir` command. `target_dir` will just be passed to the `--chdir` flag in `vendir.