### PR TITLE
Update Vendir's url

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const path = require('path')
 const fetchReleases = async () => {
   const version = core.getInput('version')
   const versionPath = version == 'latest' ? 'latest' : `tags/${version}`
-  const url = `https://api.github.com/repos/vmware-tanzu/carvel-vendir/releases/${versionPath}`
+  const url = `https://api.github.com/repos/carvel-dev/vendir/releases/${versionPath}`
   core.info(`version path = ${versionPath}`)
   core.info(`URL = ${url}`)
   core.info(`Fetching Vendir release from ${url}`)


### PR DESCRIPTION
Github redirects me from `vmware-tanzu/carvel-vendir` to `carvel-dev/vendir` but the code in index.js doesn't handle redirection codes and the action just fails.

Perhaps handling redirections is a better fix and I should leave this problem for somebody fluent in JS to fix it?

Right now github actions in my project (which uses this action-vendir) fail with this error:

```
Fetching Vendir release from https://api.github.com/repos/vmware-tanzu/carvel-vendir/releases/latest
Error: Failed to fetch releases from GitHub API, providing a token may help.
Error: {"message":"Moved Permanently","url":"https://api.github.com/repositories/228296630/releases/latest","documentation_url":"https://docs.github.com/v3/#http-redirects"}
```