### PR TITLE
 fix: upgrade node version due to node 12 being deprecated on github actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - name: create vendir.yml
         run: |
           cat >vendir.yml <<EOL
@@ -37,7 +37,7 @@ jobs:
   test-working-dir:
     runs-on: ubuntu-latest
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - name: create working directory
         run:
           mkdir kubernetes
@@ -74,7 +74,7 @@ jobs:
   test-target-dir:
     runs-on: ubuntu-latest
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - name: create target directory
         run:
           mkdir kubernetes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Execute vendir
         uses: ./
         with:
-          token: ${{ secrets.GLOVER_ACCESS_TOKEN }}
+          token: ${{ secrets.ORG_FINE_GRAINED_PAT }}
       - name: verify vendir.lock.yml
         run: |
           cat vendir.lock.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Execute vendir
         uses: ./
         with:
-          token: ${{ secrets.GLOVER_ACCESS_TOKEN }}
+          token: ${{ secrets.ORG_FINE_GRAINED_PAT }}
           working_dir: kubernetes
       - name: verify vendir.lock.yml
         working-directory: kubernetes
@@ -97,7 +97,7 @@ jobs:
       - name: Execute vendir
         uses: ./
         with:
-          token: ${{ secrets.GLOVER_ACCESS_TOKEN }}
+          token: ${{ secrets.ORG_FINE_GRAINED_PAT }}
           target_dir: kubernetes
       - name: verify vendir.lock.yml
         working-directory: kubernetes

--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     required: false
     default: "."
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Node 12 is deprecated on github actions - this action will be disabled unless upgraded.
See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/